### PR TITLE
MODE_NORMALが多重定義されている問題の修正

### DIFF
--- a/src/Omron2SMPB02E.cpp
+++ b/src/Omron2SMPB02E.cpp
@@ -33,10 +33,10 @@ int Omron2SMPB02E::read_reg16(uint8_t addr)
   uint16_t d = (read_reg(addr) << 8) | read_reg(addr + 1); // [@(addr):@(addr+1)]
   return(-(d & 0b1000000000000000) | (d & 0b0111111111111111)); // 2's complement
   return(d);
-  
+
 }
 
-Omron2SMPB02E::Omron2SMPB02E(uint8_t SDO = 1)
+Omron2SMPB02E::Omron2SMPB02E(uint8_t SDO)
 {
   i2c_addr = 0x56;
   if (SDO == 0) i2c_addr = 0x70;
@@ -59,7 +59,7 @@ void Omron2SMPB02E::begin()
   BigNumber::begin(20);
   Wire.begin();
   write_reg(IO_SETUP, 0x00); // IO_SETUP
-  /* 
+  /*
   uint32_t coe_b00_a0_ex = (uint32_t)read_reg(COE_b00_a0_ex);
   a0 = ((uint32_t)read_reg(COE_a0_1) << 12) | ((uint32_t)read_reg(COE_a0_0) << 4) | ((uint32_t)coe_b00_a0_ex & 0x0000000f);
   a0 = -(a0 & (uint32_t)1 << 19) + (a0 & ~((uint32_t)1 << 19)); // 2's complement
@@ -103,7 +103,7 @@ float Omron2SMPB02E::read_temp()
 
 BigNumber Omron2SMPB02E::read_calc_temp()
 {
-  // Tr = a0 + a1 * Dt + a2 * Dt^2 
+  // Tr = a0 + a1 * Dt + a2 * Dt^2
   // -> temp = Re / 256 [degC]
   //   Dt : raw temperature value from TEMP_TXDx reg.
 
@@ -209,4 +209,3 @@ void Omron2SMPB02E::set_filter(uint8_t mode)
 {
   write_reg(IIR_CNT, mode);
 }
-

--- a/src/Omron2SMPB02E.h
+++ b/src/Omron2SMPB02E.h
@@ -8,10 +8,6 @@
 
 #include "Arduino.h"
 
-#define MODE_SLEEP  0
-#define MODE_FORCE  1
-#define MODE_NORMAL 2
-
 // registers
 #define TEMP_TXD0 0xfc
 #define TEMP_TXD1 0xfb
@@ -123,7 +119,7 @@ class Omron2SMPB02E
   long read_raw_pressure();
   BigNumber conv_K0(int x, BigNumber a, BigNumber s);
   BigNumber conv_K1(long x);
-  
+
  public:
   Omron2SMPB02E(uint8_t SDO = 1);
   void begin();


### PR DESCRIPTION
MODE_NORMAL 2となっている定数を削除（mode = 0x03で無い時値が更新されない）
SDO = 1が.hと.cppの両方に書かれている際にコンパイルエラーが出る問題を修正