### PR TITLE
COE値が複数回呼ばれていることの修正

### DIFF
--- a/examples/sample/sample.ino
+++ b/examples/sample/sample.ino
@@ -9,6 +9,8 @@ void setup()
   Serial.begin(9600);
   prs.set_mode(MODE_NORMAL);
   delay(300);
+  prs.read_all_coe();
+  delay(300);
 }
 
 void loop()

--- a/src/Omron2SMPB02E.cpp
+++ b/src/Omron2SMPB02E.cpp
@@ -129,12 +129,15 @@ BigNumber Omron2SMPB02E::read_calc_temp()
   sprintf(dt, "%ld", read_raw_temp());
   BigNumber Bdt = (BigNumber)dt;
   long a0;
-  a0 = ((uint32_t)read_reg(COE_a0_1) << 12) | ((uint32_t)read_reg(COE_a0_0) << 4) | ((uint32_t)read_reg(COE_b00_a0_ex) & 0x0000000f);
+  // a0 = ((uint32_t)read_reg(COE_a0_1) << 12) | ((uint32_t)read_reg(COE_a0_0) << 4) | ((uint32_t)read_reg(COE_b00_a0_ex) & 0x0000000f);
+  a0 = ((uint32_t)uint8_COE_a0_1 << 12) | ((uint32_t)uint8_COE_a0_0 << 4) | ((uint32_t)uint8_COE_b00_a0_ex & 0x0000000f);
   a0 = -(a0 & (uint32_t)1 << 19) + (a0 & ~((uint32_t)1 << 19)); // 2's complement
 
   BigNumber temp = conv_K1(a0)
-    + (conv_K0(read_reg16(COE_a1), (BigNumber)A_a1, (BigNumber)S_a1)
-       + conv_K0(read_reg16(COE_a2), (BigNumber)A_a2, (BigNumber)S_a2) * Bdt) * Bdt;
+    + (conv_K0(int_COE_a1, (BigNumber)A_a1, (BigNumber)S_a1)
+       + conv_K0(int_COE_a2, (BigNumber)A_a2, (BigNumber)S_a2) * Bdt) * Bdt;
+    // + (conv_K0(read_reg16(COE_a1), (BigNumber)A_a1, (BigNumber)S_a1)
+    //    + conv_K0(read_reg16(COE_a2), (BigNumber)A_a2, (BigNumber)S_a2) * Bdt) * Bdt;
   return(temp);
 }
 
@@ -147,7 +150,8 @@ float Omron2SMPB02E::read_pressure()
   //   Tr : raw temperature from TEMP_TXDx reg.
   //   Dp : raw pressure from PRESS_TXDx reg.
   BigNumber Bprs;
-  long b00 =((uint32_t)read_reg(COE_b00_1) << 12) | ((uint32_t)read_reg(COE_b00_0) << 4) | ((uint32_t)read_reg(COE_b00_a0_ex) >> 4);
+  // long b00 =((uint32_t)read_reg(COE_b00_1) << 12) | ((uint32_t)read_reg(COE_b00_0) << 4) | ((uint32_t)read_reg(COE_b00_a0_ex) >> 4);
+  long b00 =((uint32_t)uint8_COE_b00_1 << 12) | ((uint32_t)uint8_COE_b00_0 << 4) | ((uint32_t)uint8_COE_b00_a0_ex >> 4);
 
   char dp[10];
   sprintf(dp, "%ld", read_raw_pressure());
@@ -170,15 +174,24 @@ float Omron2SMPB02E::read_pressure()
   BigNumber w;
   BigNumber w2;
   Bprs = conv_K1(b00);
-  w = conv_K0(read_reg16(COE_bt1), (BigNumber)A_bt1, (BigNumber)S_bt1);
-  w += conv_K0(read_reg16(COE_b11), (BigNumber)A_b11, (BigNumber)S_b11) * Bdp;
-  w += Btr * (conv_K0(read_reg16(COE_bt2), (BigNumber)A_bt2, (BigNumber)S_bt2)
-	      + conv_K0(read_reg16(COE_b12), (BigNumber)A_b12, (BigNumber)S_b12) * Bdp);
+  w = conv_K0(int_COE_bt1, (BigNumber)A_bt1, (BigNumber)S_bt1);
+  w += conv_K0(int_COE_b11, (BigNumber)A_b11, (BigNumber)S_b11) * Bdp;
+  w += Btr * (conv_K0(int_COE_bt2, (BigNumber)A_bt2, (BigNumber)S_bt2)
+	      + conv_K0(int_COE_b12, (BigNumber)A_b12, (BigNumber)S_b12) * Bdp);
+  // w = conv_K0(read_reg16(COE_bt1), (BigNumber)A_bt1, (BigNumber)S_bt1);
+  // w += conv_K0(read_reg16(COE_b11), (BigNumber)A_b11, (BigNumber)S_b11) * Bdp;
+  // w += Btr * (conv_K0(read_reg16(COE_bt2), (BigNumber)A_bt2, (BigNumber)S_bt2)
+	//       + conv_K0(read_reg16(COE_b12), (BigNumber)A_b12, (BigNumber)S_b12) * Bdp);
+  
   Bprs += Btr * w;
-  w = conv_K0(read_reg16(COE_bp1), (BigNumber)A_bp1, (BigNumber)S_bp1);
-  w2 = conv_K0(read_reg16(COE_bp2), (BigNumber)A_bp2, (BigNumber)S_bp2);
-  w2 += conv_K0(read_reg16(COE_b21), (BigNumber)A_b21, (BigNumber)S_b21) * Btr;
-  w2 += conv_K0(read_reg16(COE_bp3), (BigNumber)A_bp3, (BigNumber)S_bp3) * Bdp;
+  w = conv_K0(int_COE_bp1, (BigNumber)A_bp1, (BigNumber)S_bp1);
+  w2 = conv_K0(int_COE_bp2, (BigNumber)A_bp2, (BigNumber)S_bp2);
+  w2 += conv_K0(int_COE_b21, (BigNumber)A_b21, (BigNumber)S_b21) * Btr;
+  w2 += conv_K0(int_COE_bp3, (BigNumber)A_bp3, (BigNumber)S_bp3) * Bdp;
+  // w = conv_K0(read_reg16(COE_bp1), (BigNumber)A_bp1, (BigNumber)S_bp1);
+  // w2 = conv_K0(read_reg16(COE_bp2), (BigNumber)A_bp2, (BigNumber)S_bp2);
+  // w2 += conv_K0(read_reg16(COE_b21), (BigNumber)A_b21, (BigNumber)S_b21) * Btr;
+  // w2 += conv_K0(read_reg16(COE_bp3), (BigNumber)A_bp3, (BigNumber)S_bp3) * Bdp;
   w += Bdp * w2;
   Bprs += Bdp * w;
   return((float)(Bprs * (BigNumber)10000) / 10000.0);
@@ -210,3 +223,24 @@ void Omron2SMPB02E::set_filter(uint8_t mode)
   write_reg(IIR_CNT, mode);
 }
 
+void Omron2SMPB02E::read_all_coe()
+{
+  // for press
+  uint8_COE_b00_1 = read_reg(COE_b00_1);
+  uint8_COE_b00_0 = read_reg(COE_b00_0);
+  uint8_COE_b00_a0_ex = read_reg(COE_b00_a0_ex);
+  int_COE_bt1 = read_reg16(COE_bt1);
+  int_COE_b11 = read_reg16(COE_b11);
+  int_COE_bt2 = read_reg16(COE_bt2);
+  int_COE_b12 = read_reg16(COE_b12);
+  int_COE_bp1 = read_reg16(COE_bp1);
+  int_COE_bp2 = read_reg16(COE_bp2);
+  int_COE_b21 = read_reg16(COE_b21);
+  int_COE_bp3 = read_reg16(COE_bp3);
+
+  // for temp
+  uint8_COE_a0_1 = read_reg(COE_a0_1);
+  uint8_COE_a0_0 = read_reg(COE_a0_0);
+  int_COE_a1 = read_reg16(COE_a1);
+  int_COE_a2 = read_reg16(COE_a2);
+}

--- a/src/Omron2SMPB02E.h
+++ b/src/Omron2SMPB02E.h
@@ -123,6 +123,26 @@ class Omron2SMPB02E
   long read_raw_pressure();
   BigNumber conv_K0(int x, BigNumber a, BigNumber s);
   BigNumber conv_K1(long x);
+
+  // COE values
+  // for read_pressure
+  uint8_t uint8_COE_b00_1;
+  uint8_t uint8_COE_b00_0;
+  uint8_t uint8_COE_b00_a0_ex;
+  int int_COE_bt1;
+  int int_COE_b11;
+  int int_COE_bt2;
+  int int_COE_b12;
+  int int_COE_bp1;
+  int int_COE_bp2;
+  int int_COE_b21;
+  int int_COE_bp3;
+  
+  // for read_calc_temp
+  uint8_t uint8_COE_a0_1;
+  uint8_t uint8_COE_a0_0;
+  int int_COE_a1;
+  int int_COE_a2;
   
  public:
   Omron2SMPB02E(uint8_t SDO = 1);
@@ -137,5 +157,7 @@ class Omron2SMPB02E
   void set_average(uint8_t temp_avg, uint8_t pressure_avg);
   uint8_t is_busy();
   void set_filter(uint8_t mode);
+
+  void read_all_coe(); // call once 
 };
 #endif


### PR DESCRIPTION
マニュアルでは、COE_...の値は一度呼ばれればその後は圧力/温度値のみを取得すればいい、というフローチャートになっているにもかかわらず、コードでは圧力/温度を読んで計算するたびにCOEを呼びに行く（その値が変更されていないにもかかわらず）という冗長な処理になっていたため、COE値を一度最初に呼んで、その後は使いまわす、というコードに変更しました。

---- 

変更したファイル：「./src/Omron2SMPB02E.h」
- privateで各coeパラメータを定義
- publicでcoeパラメータを読むための関数read_all_coe()を定義

変更したファイル：「./src/Omron2SMPB02E.cpp」
- coeを読み込む処理を全てprivateで定義されたcoe値を使用するように変更
- void read_all_coe内でcoe値を全て読み出す

変更したファイル：「./examples/sample/sample.ino」
- set_modeの後にprs.read_all_coe()を追加

----

これで、センサの圧力値を読み込む速度が10msecほど早くなりました（温度に関しては変化はほぼ無し）